### PR TITLE
Support for lookup returning 0 entries

### DIFF
--- a/omnilake/constructs/archives/vector/runtime/query.py
+++ b/omnilake/constructs/archives/vector/runtime/query.py
@@ -196,6 +196,9 @@ class VectorStorageSearch:
 
         logging.info(f'Vector storage query returned {len(resulting_entries)} results.')
 
+        if not resulting_entries:
+            return []
+
         de_duplicated_entries = self._remove_source_duplicates(entries=resulting_entries)
 
         if prioritize_tags:

--- a/omnilake/internal_lib/event_definitions.py
+++ b/omnilake/internal_lib/event_definitions.py
@@ -155,10 +155,11 @@ class LakeRequestLookupResponse(ObjectBodySchema):
         SchemaAttribute(
             name='entry_ids',
             type=SchemaAttributeType.STRING_LIST,
-            required=True,
+            required=False,
+            default_value=[],
         ),
         SchemaAttribute(
-            name="event_type",
+            name='event_type',
             type=SchemaAttributeType.STRING,
             required=False,
             default_value="omnilake_lake_lookup_response",

--- a/omnilake/services/request_manager/runtime/stage_complete.py
+++ b/omnilake/services/request_manager/runtime/stage_complete.py
@@ -213,7 +213,7 @@ def handler(event, context):
                 lake_request=lake_request,
                 lake_requests_client=lake_requests,
                 response_status=LakeRequestStatus.FAILED,
-                status_message="No entries found",
+                status_message="Lookup returned no entries",
             )
 
             return


### PR DESCRIPTION
- Update the lookup result schema to allow for 0 entries being returned.
- Update Vector Archive to handle 0 entries being returned